### PR TITLE
Display job costs at the end

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -3,9 +3,14 @@ description: 'RunsOn Action for magic caching, and more'
 runs:
   using: 'node20'
   main: 'index.js'
+  post: 'post.js'
 
 inputs:
   show-env:
     description: 'Show all environment variables'
     required: false
     default: 'false'
+  display-costs:
+    description: 'Display execution cost summary'
+    required: false
+    default: 'true'

--- a/action.yml
+++ b/action.yml
@@ -10,7 +10,7 @@ inputs:
     description: 'Show all environment variables'
     required: false
     default: 'false'
-  display-costs:
-    description: 'Control how execution costs are displayed: "inline" for console output, "summary" for GitHub job summary, any other value disables the feature'
+  show-costs:
+    description: 'Control how execution costs are displayed: "inline" for log output, "summary" for GitHub job summary, any other value disables the feature'
     required: false
     default: 'inline'

--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,6 @@ inputs:
     required: false
     default: 'false'
   display-costs:
-    description: 'Display execution cost summary'
+    description: 'Control how execution costs are displayed: "inline" for console output, "summary" for GitHub job summary, any other value disables the feature'
     required: false
-    default: 'true'
+    default: 'inline'

--- a/action.yml
+++ b/action.yml
@@ -6,11 +6,11 @@ runs:
   post: 'post.js'
 
 inputs:
-  show-env:
+  show_env:
     description: 'Show all environment variables'
     required: false
     default: 'false'
-  show-costs:
+  show_costs:
     description: 'Control how execution costs are displayed: "inline" for log output, "summary" for GitHub job summary, any other value disables the feature'
     required: false
     default: 'inline'

--- a/post.js
+++ b/post.js
@@ -85,6 +85,7 @@ async function computeExecutionCost() {
 }
 
 async function main() {
+  console.log("env", process.env);
   await computeExecutionCost();
 }
 

--- a/post.js
+++ b/post.js
@@ -4,11 +4,11 @@ const path = require('path');
 
 async function computeExecutionCost() {
   // Get the display costs option value
-  const displayCostsOption = process.env.INPUT_DISPLAY_COSTS || 'inline';
+  const displayCostsOption = process.env.INPUT_SHOW_COSTS || 'inline';
 
   // Disable if not 'inline' or 'summary'
   if (displayCostsOption !== 'inline' && displayCostsOption !== 'summary') {
-    console.log(`Cost calculation is disabled (display-costs=${displayCostsOption})`);
+    console.log(`Cost calculation is disabled (show-costs=${displayCostsOption})`);
     return;
   }
 

--- a/post.js
+++ b/post.js
@@ -7,10 +7,10 @@ async function computeExecutionCost() {
     return;
   }
 
-  const instanceStartedAt = process.env.RUNS_ON_INSTANCE_STARTED_AT;
+  const instanceLaunchedAt = process.env.RUNS_ON_INSTANCE_LAUNCHED_AT;
   
-  if (!instanceStartedAt) {
-    console.log('RUNS_ON_INSTANCE_STARTED_AT environment variable not found. Cannot compute cost.');
+  if (!instanceLaunchedAt) {
+    console.log('RUNS_ON_INSTANCE_LAUNCHED_AT environment variable not found. Cannot compute cost.');
     return;
   }
 
@@ -32,7 +32,7 @@ async function computeExecutionCost() {
         instanceType,
         region,
         instanceLifecycle,
-        startedAt: instanceStartedAt
+        startedAt: instanceLaunchedAt
       }),
       signal: controller.signal
     });

--- a/post.js
+++ b/post.js
@@ -1,0 +1,68 @@
+const process = require('process');
+
+async function computeExecutionCost() {
+  // Check if cost display is disabled
+  if (process.env.INPUT_DISPLAY_COSTS === 'false') {
+    console.log('Cost calculation is disabled (display-costs=false)');
+    return;
+  }
+
+  const startedAt = process.env.RUNS_ON_JOB_STARTED_AT;
+  
+  if (!startedAt) {
+    console.log('RUNS_ON_JOB_STARTED_AT environment variable not found. Cannot compute cost.');
+    return;
+  }
+
+  // Get runner information from environment variables
+  const region = process.env.RUNS_ON_AWS_REGION || '';
+  const instanceType = process.env.RUNS_ON_INSTANCE_TYPE || '';
+  const instanceLifecycle = process.env.RUNS_ON_INSTANCE_LIFECYCLE || 'spot';
+
+  // get average price for the region for now
+  try {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), 5000);
+    const response = await fetch('https://ec2-pricing.runs-on.com/cost', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        instanceType,
+        region,
+        instanceLifecycle,
+        startedAt
+      }),
+      signal: controller.signal
+    });
+    clearTimeout(timeoutId);
+
+    if (!response.ok) {
+      throw new Error(`HTTP error! Status: ${response.status}`);
+    }
+
+    const costData = await response.json();
+    
+    console.log('\n===== Execution Cost Summary =====');
+    console.log(`Instance Type: ${costData.instanceType}`);
+    console.log(`Region: ${costData.region}`);
+    console.log(`Duration: ${costData.durationMinutes} minutes`);
+    console.log(`Cost: $${costData.totalCost}`);
+    console.log(`GitHub equivalent cost: $${costData.github.totalCost}`);
+    console.log(`Savings: $${costData.savings.amount} (${costData.savings.percentage}%)`);
+    console.log('==================================\n');
+
+  } catch (error) {
+    console.error('Error computing execution cost:', error);
+  }
+}
+
+async function main() {
+  await computeExecutionCost();
+}
+
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+}); 

--- a/post.js
+++ b/post.js
@@ -85,7 +85,6 @@ async function computeExecutionCost() {
 }
 
 async function main() {
-  console.log("env", process.env);
   await computeExecutionCost();
 }
 

--- a/post.js
+++ b/post.js
@@ -23,6 +23,8 @@ async function computeExecutionCost() {
   const region = process.env.RUNS_ON_AWS_REGION || '';
   const instanceType = process.env.RUNS_ON_INSTANCE_TYPE || '';
   const instanceLifecycle = process.env.RUNS_ON_INSTANCE_LIFECYCLE || 'spot';
+  // x64 or arm64
+  const instanceArchitecture = process.env.RUNS_ON_AGENT_ARCH || 'x64';
 
   // get average price for the region for now
   try {
@@ -35,8 +37,9 @@ async function computeExecutionCost() {
       },
       body: JSON.stringify({
         instanceType,
-        region,
         instanceLifecycle,
+        region,
+        arch: instanceArchitecture,
         startedAt: instanceLaunchedAt
       }),
       signal: controller.signal
@@ -44,7 +47,7 @@ async function computeExecutionCost() {
     clearTimeout(timeoutId);
 
     if (!response.ok) {
-      throw new Error(`HTTP error! Status: ${response.status}`);
+      throw new Error(`HTTP error! Status: ${response.status}: ${response.text()}`);
     }
 
     const costData = await response.json();

--- a/post.js
+++ b/post.js
@@ -7,10 +7,10 @@ async function computeExecutionCost() {
     return;
   }
 
-  const startedAt = process.env.RUNS_ON_JOB_STARTED_AT;
+  const instanceStartedAt = process.env.RUNS_ON_INSTANCE_STARTED_AT;
   
-  if (!startedAt) {
-    console.log('RUNS_ON_JOB_STARTED_AT environment variable not found. Cannot compute cost.');
+  if (!instanceStartedAt) {
+    console.log('RUNS_ON_INSTANCE_STARTED_AT environment variable not found. Cannot compute cost.');
     return;
   }
 
@@ -32,7 +32,7 @@ async function computeExecutionCost() {
         instanceType,
         region,
         instanceLifecycle,
-        startedAt
+        startedAt: instanceStartedAt
       }),
       signal: controller.signal
     });


### PR DESCRIPTION
Also compare with official GitHub runners. Defaults to displaying the cost in the post-step inline. Can also output in step summary. Can be disabled as well.

Only available starting with v2.7.0 of RunsOn.