### PR TITLE
Add Memory Available metric to memory monitoring

### DIFF
--- a/internal/monitoring/metrics.go
+++ b/internal/monitoring/metrics.go
@@ -104,6 +104,13 @@ func GetMeasurements(metric string) []Measurement {
 				Unit:        "Percent",
 				Aggregation: "Average",
 			},
+			{
+				Name:        "available_percent",
+				RealName:    "mem_available_percent",
+				Rename:      "Memory Available",
+				Unit:        "Percent",
+				Aggregation: "Average",
+			},
 		}
 	case "disk":
 		return []Measurement{


### PR DESCRIPTION
## Summary

- Adds `mem_available_percent` metric alongside the existing `mem_used_percent` when memory monitoring is enabled
- This provides a more accurate view of available memory that accounts for shared memory like tmpfs, which was skewing data when only using "Memory Used"

## Changes

- Added new `available_percent` measurement to the `memory` metric type in `GetMeasurements()`
- The CloudWatch agent will now collect both `mem_used_percent` and `mem_available_percent`
- Both metrics will be displayed in the metrics summary with ASCII charts

## Test plan

- [ ] Deploy to a test runner with `metrics: memory` enabled
- [ ] Verify both "Memory Used" and "Memory Available" charts appear in the post-execution metrics summary
- [ ] Confirm the Memory Available values account for shared memory (tmpfs)

Closes #22