### PR TITLE
update for node24

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,7 +1,7 @@
 name: 'runs-on/action'
 description: 'RunsOn Action for magic caching, and more'
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'index.js'
   post: 'post.js'
 


### PR DESCRIPTION
to fix
```
Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: runs-on/action@4bd75c6cabfe307f831797585486f95a0ae12ed1. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
```