### PR TITLE
release: emit SLSA Build Provenance attestations, not generic attestations

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -185,9 +185,13 @@ jobs:
             SHA256SUMS \
             SHA256SUMS.asc
 
-      - name: Attest release binaries
-        uses: actions/attest@v4.1.0
+      - name: Attest release binaries (SLSA Build Provenance)
+        uses: actions/attest-build-provenance@v4.1.0
         with:
+          # Each entry in SHA256SUMS becomes a separate attested subject,
+          # so consumers can verify a single binary with
+          #   gh attestation verify main-linux-amd64 --owner runs-on
+          # without having to download the full sums file first.
           subject-checksums: SHA256SUMS
 
       - name: Publish GitHub release


### PR DESCRIPTION
Resolves #36.

The release workflow on `main` already produces an attestation by
calling `actions/attest@v4.1.0` with `subject-checksums: SHA256SUMS`,
which is great — but the generic `actions/attest` action doesn't
commit to a specific predicate. Downstream verifiers that filter on
SLSA Build Provenance (the ASF `verify-action-build` pipeline that
prompted #36, but also `gh attestation verify --predicate-type
https://slsa.dev/provenance/v1`) therefore see the attestation as
"some attestation" rather than "build provenance".

`actions/attest-build-provenance@v4.1.0` is the canonical wrapper —
it pins the predicate to `https://slsa.dev/provenance/v1` and
generates SLSA-Provenance-shaped statements, but is otherwise a
drop-in replacement (it accepts the same `subject-checksums` input
and also produces one attestation per subject listed in the file).

This is the single-line fix the issue asked for. The other ask in
the issue — published release assets with a GPG-signed `SHA256SUMS`
— is already covered on `main` by the GPG sign + `gh release create`
steps in the workflow (and the verification recipe in the README's
"Release" section already shows `gh attestation verify`, so no doc
update is needed once this lands).

### Verifying the result

After this lands, downstream consumers can verify any released
binary with the standard SLSA build-provenance flow:

```bash
gh release download v2.1.2 -R runs-on/action

gpg --verify SHA256SUMS.asc SHA256SUMS
shasum -a 256 -c SHA256SUMS

gh attestation verify main-linux-amd64 \
    -R runs-on/action \
    --predicate-type https://slsa.dev/provenance/v1
```

The `--predicate-type` filter is what ASF `verify-action-build`
needs, and what fails today on releases produced by the generic
`actions/attest`.