### PR TITLE
Remove global sudo from action wrapper

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,22 +40,7 @@ function main() {
         // runner user has elevated privileges, so we can just run the script directly
         childProcess.execFileSync(mainScript, ARGS, { stdio: 'inherit' })
     } else {
-        try {
-            childProcess.execFileSync('sudo', ['-n', '-E', mainScript, ...ARGS], { stdio: 'inherit' })
-        } catch (error) {
-            try {
-                const whoami = childProcess.execSync('whoami').toString().trim()
-                console.log(`Current user (whoami): ${whoami}`)
-            } catch (error) {
-                console.log('Could not determine user via whoami')
-            }
-            if (error.code === 'ENOENT') {
-                // sudo not available (likely in container, which is already running as root), try running directly
-                childProcess.execFileSync(mainScript, ARGS, { stdio: 'inherit' })
-            } else {
-                throw error
-            }
-        }
+        childProcess.execFileSync(mainScript, ARGS, { stdio: 'inherit' })
     }
     process.exit(0)
 }

--- a/index.template.js
+++ b/index.template.js
@@ -40,22 +40,7 @@ function main() {
         // runner user has elevated privileges, so we can just run the script directly
         childProcess.execFileSync(mainScript, ARGS, { stdio: 'inherit' })
     } else {
-        try {
-            childProcess.execFileSync('sudo', ['-n', '-E', mainScript, ...ARGS], { stdio: 'inherit' })
-        } catch (error) {
-            try {
-                const whoami = childProcess.execSync('whoami').toString().trim()
-                console.log(`Current user (whoami): ${whoami}`)
-            } catch (error) {
-                console.log('Could not determine user via whoami')
-            }
-            if (error.code === 'ENOENT') {
-                // sudo not available (likely in container, which is already running as root), try running directly
-                childProcess.execFileSync(mainScript, ARGS, { stdio: 'inherit' })
-            } else {
-                throw error
-            }
-        }
+        childProcess.execFileSync(mainScript, ARGS, { stdio: 'inherit' })
     }
     process.exit(0)
 }

--- a/post.js
+++ b/post.js
@@ -40,22 +40,7 @@ function main() {
         // runner user has elevated privileges, so we can just run the script directly
         childProcess.execFileSync(mainScript, ARGS, { stdio: 'inherit' })
     } else {
-        try {
-            childProcess.execFileSync('sudo', ['-n', '-E', mainScript, ...ARGS], { stdio: 'inherit' })
-        } catch (error) {
-            try {
-                const whoami = childProcess.execSync('whoami').toString().trim()
-                console.log(`Current user (whoami): ${whoami}`)
-            } catch (error) {
-                console.log('Could not determine user via whoami')
-            }
-            if (error.code === 'ENOENT') {
-                // sudo not available (likely in container, which is already running as root), try running directly
-                childProcess.execFileSync(mainScript, ARGS, { stdio: 'inherit' })
-            } else {
-                throw error
-            }
-        }
+        childProcess.execFileSync(mainScript, ARGS, { stdio: 'inherit' })
     }
     process.exit(0)
 }


### PR DESCRIPTION
## Summary

- run the Linux action wrapper binary as the normal runner user instead of via `sudo -E`
- keep privileged CloudWatch agent operations behind their existing targeted sudo calls in the Go code
- leave the magic-cache workflow matrix unchanged until Ubuntu 26 images are available

## Why

Ubuntu 26 ignores `sudo -E`, which strips GitHub Actions cache/artifact environment variables before the action binary reads them. That prevents the RunsOn cache proxy from receiving the original `ZCTIONS_*` URLs and `ACTIONS_RUNTIME_TOKEN`, which breaks artifact upload through the local proxy.

The cache configuration path only sends an HTTP request to the local cache daemon and does not need root. Running the wrapper binary as the runner user preserves the GitHub Actions environment normally and avoids forwarding secrets through sudo.

## Validation

- `make js`
- `go test ./...`
- confirmed generated `index.js` and `post.js` no longer contain the `sudo -n -E` wrapper